### PR TITLE
Remove extra caret in units with exponents.

### DIFF
--- a/lattice/docs/schema_table.py
+++ b/lattice/docs/schema_table.py
@@ -84,7 +84,7 @@ def data_elements_dict_from_data_groups(data_groups):
                     new_obj["Units"] = r"\-"
                 else:
                     new_obj["Units"] = new_obj["Units"].replace("-", r"·")
-                    new_obj["Units"] = re.sub(r"(\d+)", r"^\1^", new_obj["Units"])
+                    new_obj["Units"] = re.sub(r"(\d+)", r"^\1", new_obj["Units"])
             compress_notes(new_obj)
             data_elements.append(new_obj)
         output[dat_gr] = data_elements


### PR DESCRIPTION
Regex sub was adding a trailing caret to units. For example, m3/s was rendered as m^3^/s.

This PR removes the trailing caret so that m3/s is rendered as m^3/s.