### PR TITLE
Validation fixes

### DIFF
--- a/lattice/lattice.py
+++ b/lattice/lattice.py
@@ -143,8 +143,8 @@ class Lattice:  # pylint:disable=R0902
         if schema_type is None:
             if len(self.schemas) > 1:
                 raise Exception(
-                    "Too many schema available for validation; cannot find a match to"
-                    ' "schema_name" in "{input_path}." Unable to validate file.'
+                    f"Too many schema available for validation; cannot find a match to"
+                    f' "schema_name" {schema_type} in "{input_path}." Unable to validate file.'
                 ) from None
             validate_file(input_path, self.schemas[0].json_schema_path)
             postvalidate_file(input_path, self.schemas[0].json_schema_path)

--- a/lattice/schema.py
+++ b/lattice/schema.py
@@ -115,12 +115,12 @@ class ArrayType(DataType):
 
 
 _value_pattern = RegularExpressionPattern(
-    f"({_type_base_names})|"
+    f"({_type_base_names})|"  # A constraint can be the name of a Data Group
     f"({NumericType.value_pattern})|"
     f"({StringType.value_pattern})|"
     f"({EnumerationType.value_pattern})|"
     f"({BooleanType.value_pattern})"
-)  # A constraint can be the name of a Data Group
+)
 
 
 # Constraints

--- a/test/test_schema_patterns.py
+++ b/test/test_schema_patterns.py
@@ -1,7 +1,7 @@
-import lattice.schema
-
 # Needed for python versions < 3.9. 3.8 reaches end-of-life 2024-10.
 from typing import List
+
+import lattice.schema
 
 
 def execute_pattern_test(
@@ -10,7 +10,6 @@ def execute_pattern_test(
     invalid_examples: List[str],
     anchored: bool = True,
 ) -> None:
-
     pattern_text = pattern.anchored() if anchored else pattern.pattern
 
     for test in valid_examples:
@@ -40,7 +39,6 @@ def test_integer_pattern():
 
 
 def test_data_type_pattern():
-
     execute_pattern_test(
         pattern=lattice.schema.SchemaPatterns().data_types,
         valid_examples=[
@@ -53,7 +51,6 @@ def test_data_type_pattern():
 
 
 def test_enumerator_pattern():
-
     execute_pattern_test(
         pattern=lattice.schema.EnumerationType.value_pattern,
         valid_examples=[
@@ -70,14 +67,23 @@ def test_enumerator_pattern():
 def test_value_pattern():
     execute_pattern_test(
         pattern=lattice.schema._value_pattern,
-        valid_examples=["3.14", '""', '"String"', "True", "False", "ENUMERATOR", "ENUMERATOR_2", "NEW_ENUMERATOR"],
-        invalid_examples=["Wrong", "true", "false"],
+        valid_examples=[
+            "3.14",
+            '""',
+            '"String"',
+            "RightOh",
+            "True",
+            "False",
+            "ENUMERATOR",
+            "ENUMERATOR_2",
+            "NEW_ENUMERATOR",
+        ],
+        invalid_examples=["true", "false"],
         anchored=True,
     )
 
 
 def test_data_element_value_constraint_pattern():
-
     execute_pattern_test(
         pattern=lattice.schema.DataElementValueConstraint.pattern,
         valid_examples=["schema=RS0001"],
@@ -87,7 +93,6 @@ def test_data_element_value_constraint_pattern():
 
 
 def test_selector_constraint_pattern():
-
     execute_pattern_test(
         pattern=lattice.schema.SelectorConstraint.pattern,
         valid_examples=["operation_speed_control_type(CONTINUOUS, DISCRETE)"],


### PR DESCRIPTION
There are two substantive changes; the rest are formatting and linting.

Line 118 in schema.py & line 70 in test_schema_patterns.py: The Schema class was in fact already being used to initialize the list of schema for Lattice. However, the `_schema_name` attribute used a regex from a constraint that didn't allow for CamelCase file names, and so "HPWHSimInput" couldn't be a schema name, it was being truncated to "HPWHS".

I'm not sure this solution preserves the intent of `_value_pattern` though, so it could use scrutiny.