### PR TITLE
CPP should only mark a variable as required if Required: True.

### DIFF
--- a/lattice/cpp/header_entries.py
+++ b/lattice/cpp/header_entries.py
@@ -179,7 +179,7 @@ class DataElement(HeaderEntry):
         super().__post_init__()
         self._closure = ";"
         self._element_attributes = self._data_group_attributes[self.name]
-        self.is_required: bool = self._element_attributes.get("Required", False)  # used externally
+        self.is_required: bool = True if self._element_attributes.get("Required") == True else False  # noqa E712
         self.scoped_innertype: tuple[str, str] = ("", "")
 
         self._create_type_entry(self._element_attributes)


### PR DESCRIPTION
Temporary (?) fix to address Issue #90.
The json capture code will only populate the "is_required" parameter with "true" if the schema uses literally Required: True (not Required: some conditional thing.)