### PR TITLE
Fix markdown grid tables version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "lattice"
-version = "0.0.0" # Generated from git on CI
+version = "0.0.0"                                                                                       # Generated from git on CI
 description = "A framework for developing data models, including schema development and documentation."
-authors = [{name="Big Ladder Software"}]
+authors = [{ name = "Big Ladder Software" }]
 #license = "BSD-3"
 readme = "README.md"
 keywords = ["data-modeling", "schema", "lattice"]
@@ -16,8 +16,8 @@ dependencies = [
     "stringcase >=1.2.0",
     "pygit2 >=1.15.1",
     "mkdocs-material",
-    "markdown-grid-tables",
-    "networkx"
+    "markdown-grid-tables == 0.4.0", # Note: issue with later versions (https://gitlab.com/WillDaSilva/markdown_grid_tables/-/issues/4)
+    "networkx",
 ]
 
 [tool.uv]
@@ -27,7 +27,7 @@ dev-dependencies = [
     "pre-commit",
     "pylint",
     "ruff",
-    "mypy"
+    "mypy",
 ]
 
 [tool.ruff]
@@ -35,7 +35,8 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "PL", "I001"]
-ignore = ["F405", # undefined-local-with-import-star-usage
+ignore = [
+    "F405", # undefined-local-with-import-star-usage
 ]
 
 [tool.mypy]
@@ -45,7 +46,7 @@ check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "lattice.*"
-disable_error_code = ["annotation-unchecked","import"]
+disable_error_code = ["annotation-unchecked", "import"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ requires-dist = [
     { name = "cbor2" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "jsonschema" },
-    { name = "markdown-grid-tables" },
+    { name = "markdown-grid-tables", specifier = "==0.4.0" },
     { name = "mkdocs-material" },
     { name = "networkx" },
     { name = "pygit2", specifier = ">=1.15.1" },


### PR DESCRIPTION
A new version of the markdown-grid-tables broke the way we are handling definition lists. Issue posted [here](https://gitlab.com/WillDaSilva/markdown_grid_tables/-/issues/4). We'll peg the version for now to the one that worked.